### PR TITLE
Sending copy of dictionary of forward_params to torch_single_train

### DIFF
--- a/flood_forecast/pytorch_training.py
+++ b/flood_forecast/pytorch_training.py
@@ -95,7 +95,7 @@ def train_transformer_style(
             takes_target,
             meta_model,
             meta_representation,
-            forward_params)
+            forward_params.copy())
         print("The loss for epoch " + str(epoch))
         print(total_loss)
         use_decoder = False


### PR DESCRIPTION
#197 
Sending copy of dictionary of forward_params, instead of dictionary itself
won't send "target" key with Tensor in model.params and cause issue during saving model