### PR TITLE
Informer GPU Support + label len bug

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ of datasets.
    pytorch_training
    time_model
    trainer
+   explain_model_output
 
 .. automodule:: flood_forecast.deployment
 
@@ -77,8 +78,6 @@ of datasets.
   :caption: GCP Integration:
 
   basic_utils
-
-.. automodule:: flood_forecast.explain_model_output
 
 .. automodule:: flood_forecast.da_rnn
 

--- a/docs/source/training_utils.rst
+++ b/docs/source/training_utils.rst
@@ -1,7 +1,7 @@
 Training Utils
 ==================
 
-This module includes functions that useful 
+This module includes functions that useful for training .
 
 .. automodule:: flood_forecast.training_utils
     :members:

--- a/flood_forecast/evaluator.py
+++ b/flood_forecast/evaluator.py
@@ -102,6 +102,9 @@ def evaluate_model(
             # df_prediction_samples_std_dev,
         ) = infer_on_torch_model(model, **inference_params)
         # To-do turn this into a general function
+        print("Shape info below")
+        print(end_tensor.shape)
+        print(df_train_and_test)
         g_loss = False
         probablistic = True if "probabilistic" in inference_params else False
         if isinstance(end_tensor, tuple) and not probablistic:

--- a/flood_forecast/evaluator.py
+++ b/flood_forecast/evaluator.py
@@ -102,9 +102,6 @@ def evaluate_model(
             # df_prediction_samples_std_dev,
         ) = infer_on_torch_model(model, **inference_params)
         # To-do turn this into a general function
-        print("Shape info below")
-        print(end_tensor.shape)
-        print(df_train_and_test)
         g_loss = False
         probablistic = True if "probabilistic" in inference_params else False
         if isinstance(end_tensor, tuple) and not probablistic:

--- a/flood_forecast/explain_model_output.py
+++ b/flood_forecast/explain_model_output.py
@@ -33,7 +33,10 @@ def handle_dl_output(dl, dl_class: str, datetime_start: datetime, device: str) -
     """
     if dl_class == "TemporalLoader":
         his, tar, _, forecast_start_idx = dl.get_from_start_date(datetime_start)
-        history = [his[0].unsqueeze(0), his[1].unsqueeze(0), tar[1].unsqueeze(0), tar[0].unsqueeze(0)]
+        t = tar[1].unsqueeze(0).to(device)
+        t1 = tar[0].unsqueeze(0).to(device)
+        history = [his[0].unsqueeze(0).to(device), his[1].unsqueeze(0).to(device), t,
+                   t1]
     else:
         history, _, forecast_start_idx = dl.get_from_start_date(datetime_start)
         history = history.to(device).unsqueeze(0)
@@ -92,6 +95,7 @@ def deep_explain_model_summary_plot(
 
     history, forecast_start_idx = handle_dl_output(csv_test_loader, model.params["dataset_params"]["class"],
                                                    datetime_start, device)
+    
     background_tensor = _prepare_background_tensor(csv_test_loader)
     background_tensor = background_tensor.to(device)
     model.model.eval()

--- a/flood_forecast/explain_model_output.py
+++ b/flood_forecast/explain_model_output.py
@@ -95,7 +95,6 @@ def deep_explain_model_summary_plot(
 
     history, forecast_start_idx = handle_dl_output(csv_test_loader, model.params["dataset_params"]["class"],
                                                    datetime_start, device)
-    
     background_tensor = _prepare_background_tensor(csv_test_loader)
     background_tensor = background_tensor.to(device)
     model.model.eval()

--- a/flood_forecast/explain_model_output.py
+++ b/flood_forecast/explain_model_output.py
@@ -32,6 +32,7 @@ def handle_dl_output(dl, dl_class: str, datetime_start: datetime, device: str) -
     :rtype: Tuple[torch.Tensor, int]
     """
     if dl_class == "TemporalLoader":
+        device = "cpu"
         his, tar, _, forecast_start_idx = dl.get_from_start_date(datetime_start)
         t = tar[1].unsqueeze(0).to(device)
         t1 = tar[0].unsqueeze(0).to(device)
@@ -103,6 +104,7 @@ def deep_explain_model_summary_plot(
     # L - batch size, N - history length, M - feature size
     s_values_list = []
     if isinstance(history, list):
+        model.model = model.model.to("cpu")
         deep_explainer = shap.DeepExplainer(model.model, history)
         shap_values = deep_explainer.shap_values(history)
         s_values_list.append(shap_values)

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -370,6 +370,7 @@ class TemporalTestLoader(CSVTestLoader):
             temporal_feat = self.temporal_df.iloc[idx: self.forecast_history + idx]
             end_idx = self.forecast_total + target_idx_start
             if self.decoder_step_len:
+                targs_idx_start = targs_idx_start - self.decoder_step_len
                 end_idx = self.forecast_total + target_idx_start + self.decoder_step_len
                 tar_temporal_feats = self.temporal_df.iloc[targs_idx_start: end_idx]
                 targ_rows = self.other_feats.iloc[targs_idx_start: end_idx]

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -310,7 +310,7 @@ class TemporalLoader(CSVDataLoader):
         self.time_feats = time_feats
         self.temporal_df = self.df[time_feats]
         self.other_feats = self.df.drop(columns=time_feats)
-        self.label_len = self.label_len
+        self.label_len = label_len
 
     @staticmethod
     def df_to_numpy(pandas_stuff: pd.DataFrame):

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -372,8 +372,10 @@ class TemporalTestLoader(CSVTestLoader):
             if self.decoder_step_len:
                 print("The label length is " + str(self.decoder_step_len))
                 targs_idx_start = targs_idx_start - self.decoder_step_len
+                print(targs_idx_start)
                 target_idx_start = targs_idx_start - self.decoder_step_len
                 end_idx = self.forecast_total + target_idx_start + self.decoder_step_len
+                print(end_idx)
                 tar_temporal_feats = self.temporal_df.iloc[targs_idx_start: end_idx]
                 targ_rows = self.other_feats.iloc[targs_idx_start: end_idx]
             else:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -309,6 +309,7 @@ class TemporalLoader(CSVDataLoader):
         self.time_feats = time_feats
         self.temporal_df = self.df[time_feats]
         self.other_feats = self.df.drop(columns=time_feats)
+        self.label_len = 0
 
     @staticmethod
     def df_to_numpy(pandas_stuff: pd.DataFrame):
@@ -317,11 +318,12 @@ class TemporalLoader(CSVDataLoader):
     def __getitem__(self, idx: int):
         rows = self.other_feats.iloc[idx: self.forecast_history + idx]
         temporal_feats = self.temporal_df.iloc[idx: self.forecast_history + idx]
-        targs_idx_start = self.forecast_history + idx
+        targs_idx_start = self.forecast_history + idx - self.label_len
         targ_rows = self.other_feats.iloc[
-            targs_idx_start: self.forecast_length + targs_idx_start
+            targs_idx_start: self.forecast_length + targs_idx_start + self.label_len
         ]
-        tar_temporal_feats = self.temporal_df.iloc[targs_idx_start: self.forecast_length + targs_idx_start]
+        targs_idx_s = targs_idx_start
+        tar_temporal_feats = self.temporal_df.iloc[targs_idx_s: self.forecast_length + targs_idx_start + self.label_len]
         src_data = self.df_to_numpy(rows)
         trg_data = self.df_to_numpy(targ_rows)
         temporal_feats = self.df_to_numpy(temporal_feats)

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -370,7 +370,9 @@ class TemporalTestLoader(CSVTestLoader):
             temporal_feat = self.temporal_df.iloc[idx: self.forecast_history + idx]
             end_idx = self.forecast_total + target_idx_start
             if self.decoder_step_len:
+                print("The label length is " + str(self.decoder_step_len))
                 targs_idx_start = targs_idx_start - self.decoder_step_len
+                target_idx_start = targs_idx_start - self.decoder_step_len
                 end_idx = self.forecast_total + target_idx_start + self.decoder_step_len
                 tar_temporal_feats = self.temporal_df.iloc[targs_idx_start: end_idx]
                 targ_rows = self.other_feats.iloc[targs_idx_start: end_idx]

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -373,7 +373,7 @@ class TemporalTestLoader(CSVTestLoader):
                 print("The label length is " + str(self.decoder_step_len))
                 targs_idx_start = targs_idx_start - self.decoder_step_len
                 print(targs_idx_start)
-                target_idx_start = targs_idx_start - self.decoder_step_len
+                target_idx_start = target_idx_start - self.decoder_step_len
                 end_idx = self.forecast_total + target_idx_start + self.decoder_step_len
                 print(end_idx)
                 tar_temporal_feats = self.temporal_df.iloc[targs_idx_start: end_idx]

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -385,8 +385,9 @@ class TemporalTestLoader(CSVTestLoader):
             trg_data = self.df_to_numpy(targ_rows)
             temporal_feat = self.df_to_numpy(temporal_feat)
             tar_temp = self.df_to_numpy(tar_temporal_feats)
+            decoder_adjust = self.decoder_step_len if self.decoder_step_len else 0
             all_rows_orig = self.original_df.iloc[
-                idx: self.forecast_total + target_idx_start
+                idx: self.forecast_total + target_idx_start + decoder_adjust
             ].copy()
             historical_rows = torch.from_numpy(historical_rows.to_numpy())
             return (src_data, temporal_feat), (tar_temp, trg_data), all_rows_orig, target_idx_start

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -297,7 +297,8 @@ class TemporalLoader(CSVDataLoader):
     def __init__(
             self,
             time_feats: List[str],
-            kwargs):
+            kwargs,
+            label_len=0):
         """[summary]
 
         :param time_feats: [description]
@@ -309,7 +310,7 @@ class TemporalLoader(CSVDataLoader):
         self.time_feats = time_feats
         self.temporal_df = self.df[time_feats]
         self.other_feats = self.df.drop(columns=time_feats)
-        self.label_len = 0
+        self.label_len = self.label_len
 
     @staticmethod
     def df_to_numpy(pandas_stuff: pd.DataFrame):

--- a/flood_forecast/temporal_decoding.py
+++ b/flood_forecast/temporal_decoding.py
@@ -70,4 +70,4 @@ def decoding_function(model, src: torch.Tensor, trg: torch.Tensor, forecast_leng
             filled_target = torch.cat((filled_target, filled_target1), dim=1)
         assert out1[0, 0, 0] != 0
         assert out1[0, 0, 0] != 0
-    return out1[:, -max_len:, :n_target]
+    return out1[:, :, :n_target]

--- a/flood_forecast/temporal_decoding.py
+++ b/flood_forecast/temporal_decoding.py
@@ -53,7 +53,7 @@ def decoding_function(model, src: torch.Tensor, trg: torch.Tensor, forecast_leng
     print(trg[:, d - forecast_length:decoder_seq_len, :].shape)
     filled_target = filled_target.to(device)
     # assert filled_target[:, -forecast_length:, :].any() != trg[:, d - forecast_length:decoder_seq_len, :].any()
-    assert filled_target[0, -forecast_length, 0] != trg[0, -forecast_length, 0]
+    assert filled_target[0, -decoder_seq_len, 0] != trg[0, -decoder_seq_len, 0]
     assert filled_target[0, -1, 0] != trg[0, -1, 0]
     for i in range(0, max_len, forecast_length):
         residual = decoder_seq_len if i + decoder_seq_len <= max_len else max_len % decoder_seq_len

--- a/flood_forecast/temporal_decoding.py
+++ b/flood_forecast/temporal_decoding.py
@@ -9,7 +9,7 @@ def decoding_function(model, src: torch.Tensor, trg: torch.Tensor, forecast_leng
     Instead only the data to the decoder (e.g. the masked trg) is changed when forecasting max_len > forecast_length.
     New data is appended (forecast_len == 2) (decoder_seq==10) (max==20) (20 (8)->2 First 8 should
 
-    :param model: The PyTorch time series forecasting model for
+    :param model: The PyTorch time series forecasting model that you want to use forecasting on.
     :type model: `torch.nn.Module`
     :param src: The forecast_history tensor. Should be of dimension (batch_size, forecast_history, n_time_series).
     Ocassionally batch_size will not be present so at some points it will only be (forecast_history, n_time_series)

--- a/flood_forecast/temporal_decoding.py
+++ b/flood_forecast/temporal_decoding.py
@@ -70,4 +70,4 @@ def decoding_function(model, src: torch.Tensor, trg: torch.Tensor, forecast_leng
             filled_target = torch.cat((filled_target, filled_target1), dim=1)
         assert out1[0, 0, 0] != 0
         assert out1[0, 0, 0] != 0
-    return out1[:, :, :n_target]
+    return out1[:, -max_len:, :n_target]

--- a/flood_forecast/time_model.py
+++ b/flood_forecast/time_model.py
@@ -220,9 +220,14 @@ class PyTorchForecast(TimeSeriesModel):
             start_end_params["forecast_length"] = dataset_params["forecast_length"]
             start_end_params["target_col"] = dataset_params["target_col"]
             start_end_params["relevant_cols"] = dataset_params["relevant_cols"]
+            label_len = 0
+            if "label_len" in dataset_params:
+                label_len = dataset_params["label_len"]
+
             loader = TemporalLoader(
                 dataset_params["temporal_feats"],
-                start_end_params)
+                start_end_params,
+                label_len=label_len)
         else:
             # TODO support custom DataLoader
             loader = None

--- a/flood_forecast/trainer.py
+++ b/flood_forecast/trainer.py
@@ -14,7 +14,7 @@ from flood_forecast.plot_functions import (
     plot_df_test_with_probabilistic_confidence_interval)
 
 
-def train_function(model_type: str, params: Dict):
+def train_function(model_type: str, params: Dict) -> PyTorchForecast:
     """Function to train a Model(TimeSeriesModel) or da_rnn. Will return the trained model
     :param model_type: Type of the model. In almost all cases this will be 'PyTorch'
     :type model_type: str

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -118,8 +118,8 @@ class Informer(nn.Module):
         :param dec_self_mask: [description], defaults to None
         :type dec_self_mask: [type], optional
         :param dec_enc_mask: [description], defaults to None
-        :type dec_enc_mask: [type], optional
-        :return: Returns a PyTorch tensor of shape (batch_size, ?, ?)
+        :type dec_enc_mask: torch.Tensor, optional
+        :return: Returns a PyTorch tensor of shape (batch_size, out_len, n_targets)
         :rtype: torch.Tensor
         """
         enc_out = self.enc_embedding(x_enc, x_mark_enc)

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -22,9 +22,9 @@ class Informer(nn.Module):
         :type c_out:  int
         :param seq_len: The number of historical time steps to pass into the model.
         :type seq_len: int
-        :param label_len: The length of the label sequence passed into the decoder.
+        :param label_len: The length of the label sequence passed into the decoder (n_time_steps not used forecasted)
         :type label_len: int
-        :param out_len: The overall output length from the decoder .
+        :param out_len: The predicted number of time steps. forecast_length should equal out_len + label_len
         :type out_len: int
         :param factor: The multiplicative factor in the probablistic attention mechanism, defaults to 5
         :type factor: int, optional
@@ -38,7 +38,7 @@ class Informer(nn.Module):
         :type d_layers: int, optional
         :param d_ff: The dimension of the forward pass, defaults to 512
         :type d_ff: int, optional
-        :param dropout: [description], defaults to 0.0
+        :param dropout: Whether to use dropout, defaults to 0.0
         :type dropout: float, optional
         :param attn: The type of the attention mechanism either 'prob' or 'full', defaults to 'prob'
         :type attn: str, optional

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -114,11 +114,11 @@ class Informer(nn.Module):
         :param x_mark_dec: A tensor with the relevant datetime information. (batch_size, seq_len, n_datetime_feats)
         :type x_mark_dec: torch.Tensor
         :param enc_self_mask: The mask of the encoder model has size (), defaults to None
-        :type enc_self_mask: [type], optional
+        :type enc_self_mask: torch.Tensor, optional
         :param dec_self_mask: [description], defaults to None
         :type dec_self_mask: [type], optional
         :param dec_enc_mask: [description], defaults to None
-        :type dec_enc_mask: [type], optional
+        :type dec_enc_mask: torch.Tensor, optional
         :return: Returns a PyTorch tensor of shape (batch_size, ?, ?)
         :rtype: torch.Tensor
         """

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -101,7 +101,7 @@ class Informer(nn.Module):
         # self.end_conv2 = nn.Conv1d(in_channels=d_model, out_channels=c_out, kernel_size=1, bias=True)
         self.projection = nn.Linear(d_model, c_out, bias=True)
 
-    def forward(self, x_enc, x_mark_enc, x_dec, x_mark_dec,
+    def forward(self, x_enc: torch.Tensor, x_mark_enc, x_dec, x_mark_dec,
                 enc_self_mask=None, dec_self_mask=None, dec_enc_mask=None):
         """
 

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -114,11 +114,11 @@ class Informer(nn.Module):
         :param x_mark_dec: A tensor with the relevant datetime information. (batch_size, seq_len, n_datetime_feats)
         :type x_mark_dec: torch.Tensor
         :param enc_self_mask: The mask of the encoder model has size (), defaults to None
-        :type enc_self_mask: torch.Tensor, optional
+        :type enc_self_mask: [type], optional
         :param dec_self_mask: [description], defaults to None
         :type dec_self_mask: [type], optional
         :param dec_enc_mask: [description], defaults to None
-        :type dec_enc_mask: torch.Tensor, optional
+        :type dec_enc_mask: [type], optional
         :return: Returns a PyTorch tensor of shape (batch_size, ?, ?)
         :rtype: torch.Tensor
         """

--- a/flood_forecast/transformer_xl/informer.py
+++ b/flood_forecast/transformer_xl/informer.py
@@ -44,7 +44,7 @@ class Informer(nn.Module):
         :type attn: str, optional
         :param embed: Whether to use class: `FixedEmbedding` or `torch.nn.Embbeding` , defaults to 'fixed'
         :type embed: str, optional
-        :param temp_depth: The temporald depth (e.g), defaults to 4
+        :param temp_depth: The temporald depth (e.g year, month, day, weekday, etc), defaults to 4
         :type data: int, optional
         :param activation: The activation func, defaults to 'gelu'
         :type activation: str, optional

--- a/tests/custom_encode.json
+++ b/tests/custom_encode.json
@@ -37,7 +37,7 @@
 
        },
        "lr": 0.3,
-       "epochs": 20,
+       "epochs": 30,
        "batch_size":4
     
     }, 

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -98,8 +98,3 @@ class TestInformer(unittest.TestCase):
         d = decoding_function(self.informer, src, trg, 5, src1, trg1, 1, 20, 336, "cpu")
         self.assertEqual(d.shape[0], 1)
         self.assertEqual(d.shape[1], 336)
-
-    def test_temporal_load_2(self):
-        loader = TemporalLoader(["hour"], self.kwargs, 30)
-        self.assertEqual(loader[0][0].shape[0], 30)
-        self.assertEqual(loader[0][0].shape[1], 5)

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -100,11 +100,30 @@ class TestInformer(unittest.TestCase):
         self.assertEqual(d.shape[1], 336)
 
     def test_t_loade2(self):
-        t_load = TemporalLoader(["hour"], self.kwargs, 30)
+        s_wargs = {
+                    "file_path": "tests/test_data/keag_small.csv",
+                    "forecast_history": 30,
+                    "forecast_length": 2,
+                    "target_col": ["cfs"],
+                    "relevant_cols": ["cfs", "temp", "precip"],
+                    "sort_column": "date",
+                    "feature_params":
+                    {
+                        "datetime_params": {
+                            "month": "numerical",
+                            "day": "numerical",
+                            "day_of_week": "numerical",
+                            "hour": "numerical"
+                        }
+                    }
+                }
+        s_wargs["forecast_history"] = 39
+        t_load = TemporalLoader(["hour"], s_wargs, 30)
         src, trg = t_load[0]
-        self.assertEqual(trg[1][0].shape[0], 30)
-        self.assertEqual(trg[0][0].shape[0], 30)
-        self.assertEqual(trg[1][1].shape[0], 3)
-        self.assertEqual(trg[0][1].shape[1], 3)
+        print(trg[1].shape)
+        self.assertEqual(trg[1].shape[0], 30)
+        self.assertEqual(trg[0].shape[0], 30)
+        self.assertEqual(trg[1].shape[0], 3)
+        self.assertEqual(trg[0].shape[1], 3)
         #  this test makes sure the label_len parameter works
         print("Complet")

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -102,7 +102,7 @@ class TestInformer(unittest.TestCase):
     def test_t_loade2(self):
         s_wargs = {
                     "file_path": "tests/test_data/keag_small.csv",
-                    "forecast_history": 39,
+                    "forecast_history": 30,
                     "forecast_length": 2,
                     "target_col": ["cfs"],
                     "relevant_cols": ["cfs", "temp", "precip"],

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -118,7 +118,7 @@ class TestInformer(unittest.TestCase):
                     }
                 }
         s_wargs["forecast_history"] = 39
-        t_load = TemporalLoader(["hour"], s_wargs, 30
+        t_load = TemporalLoader(["hour"], s_wargs, 30)
         src, trg = t_load[0]
         print(trg[1].shape)
         self.assertEqual(trg[1].shape[0], 32)

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -123,7 +123,7 @@ class TestInformer(unittest.TestCase):
         print(trg[1].shape)
         self.assertEqual(trg[1].shape[0], 32)
         self.assertEqual(trg[0].shape[0], 32)
-        self.assertEqual(trg[1].shape[0], 3)
+        self.assertEqual(trg[1].shape[1], 3)
         self.assertEqual(trg[0].shape[1], 3)
         #  this test makes sure the label_len parameter works
         print("Complet")

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -118,11 +118,11 @@ class TestInformer(unittest.TestCase):
                     }
                 }
         s_wargs["forecast_history"] = 39
-        t_load = TemporalLoader(["hour"], s_wargs, 30)
+        t_load = TemporalLoader(["hour"], s_wargs, 30
         src, trg = t_load[0]
         print(trg[1].shape)
-        self.assertEqual(trg[1].shape[0], 30)
-        self.assertEqual(trg[0].shape[0], 30)
+        self.assertEqual(trg[1].shape[0], 32)
+        self.assertEqual(trg[0].shape[0], 32)
         self.assertEqual(trg[1].shape[0], 3)
         self.assertEqual(trg[0].shape[1], 3)
         #  this test makes sure the label_len parameter works

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -98,3 +98,8 @@ class TestInformer(unittest.TestCase):
         d = decoding_function(self.informer, src, trg, 5, src1, trg1, 1, 20, 336, "cpu")
         self.assertEqual(d.shape[0], 1)
         self.assertEqual(d.shape[1], 336)
+
+    def test_temporal_load_2(self):
+        loader = TemporalLoader(["hour"], self.kwargs, 30)
+        self.assertEqual(loader[0][0].shape[0], 30)
+        self.assertEqual(loader[0][0].shape[1], 5)

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -101,10 +101,10 @@ class TestInformer(unittest.TestCase):
 
     def test_t_loade2(self):
         t_load = TemporalLoader(["hour"], self.kwargs, 30)
-        src, trg = t_load
+        src, trg = t_load[0]
         self.assertEqual(trg[1].shape[0], 30)
         self.assertEqual(trg[0].shape[0], 30)
         self.assertEqual(trg[1].shape[0], 3)
         self.assertEqual(trg[0].shape[1], 3)
-        #  this test makes sure the label_len param works
+        #  this test makes sure the label_len parameter works
         print("Complet")

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -102,9 +102,9 @@ class TestInformer(unittest.TestCase):
     def test_t_loade2(self):
         t_load = TemporalLoader(["hour"], self.kwargs, 30)
         src, trg = t_load[0]
-        self.assertEqual(trg[1].shape[0], 30)
-        self.assertEqual(trg[0].shape[0], 30)
-        self.assertEqual(trg[1].shape[0], 3)
-        self.assertEqual(trg[0].shape[1], 3)
+        self.assertEqual(trg[1][0].shape[0], 30)
+        self.assertEqual(trg[0][0].shape[0], 30)
+        self.assertEqual(trg[1][1].shape[0], 3)
+        self.assertEqual(trg[0][1].shape[1], 3)
         #  this test makes sure the label_len parameter works
         print("Complet")

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -77,7 +77,7 @@ class TestInformer(unittest.TestCase):
         }
         d = TemporalTestLoader(["month", "day", "day_of_week", "hour"], kwargs3, 3)
         src, trg, df, _ = d[0]
-        self.assertEqual(trg[0].shape[0], 354)
+        self.assertEqual(trg[0].shape[0], 339)
         self.assertEqual(src[0].shape[0], 5)
         self.assertEqual(len(df.index), 341)
 

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -98,3 +98,13 @@ class TestInformer(unittest.TestCase):
         d = decoding_function(self.informer, src, trg, 5, src1, trg1, 1, 20, 336, "cpu")
         self.assertEqual(d.shape[0], 1)
         self.assertEqual(d.shape[1], 336)
+
+    def test_t_loade2(self):
+        t_load = TemporalLoader(["hour"], self.kwargs, 30)
+        src, trg = t_load
+        self.assertEqual(trg[1].shape[0], 30)
+        self.assertEqual(trg[0].shape[0], 30)
+        self.assertEqual(trg[1].shape[0], 3)
+        self.assertEqual(trg[0].shape[1], 3)
+        #  this test makes sure the label_len param works
+        print("Complet")

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -102,7 +102,7 @@ class TestInformer(unittest.TestCase):
     def test_t_loade2(self):
         s_wargs = {
                     "file_path": "tests/test_data/keag_small.csv",
-                    "forecast_history": 30,
+                    "forecast_history": 39,
                     "forecast_length": 2,
                     "target_col": ["cfs"],
                     "relevant_cols": ["cfs", "temp", "precip"],

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -101,7 +101,7 @@ class TestInformer(unittest.TestCase):
 
     def test_t_loade2(self):
         t_load = TemporalLoader(["hour"], self.kwargs, 30)
-        src, trg = t_load[0]
+        src, trg = t_load
         self.assertEqual(trg[1].shape[0], 30)
         self.assertEqual(trg[0].shape[0], 30)
         self.assertEqual(trg[1].shape[0], 3)

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -101,7 +101,7 @@ class TestInformer(unittest.TestCase):
 
     def test_t_loade2(self):
         t_load = TemporalLoader(["hour"], self.kwargs, 30)
-        src, trg = t_load
+        src, trg = t_load[0]
         self.assertEqual(trg[1].shape[0], 30)
         self.assertEqual(trg[0].shape[0], 30)
         self.assertEqual(trg[1].shape[0], 3)

--- a/tests/test_informer.py
+++ b/tests/test_informer.py
@@ -75,7 +75,7 @@ class TestInformer(unittest.TestCase):
             "df_path": "tests/test_data2/keag_small.csv",
             "kwargs": kwargs2
         }
-        d = TemporalTestLoader(["month", "day", "day_of_week", "hour"], kwargs3, 18)
+        d = TemporalTestLoader(["month", "day", "day_of_week", "hour"], kwargs3, 3)
         src, trg, df, _ = d[0]
         self.assertEqual(trg[0].shape[0], 354)
         self.assertEqual(src[0].shape[0], 5)


### PR DESCRIPTION
This PR aims to fix following issues 
- [x] Allow using SHAP on GPU Informer models
- [ ]  Fix SHAP values being zero on Informer models
- [x] Fix bug related to decoding and label length inf.
- [ ] Lay the ground-work for logging all Informer values to SHAP plots (separate issue)

It is a continuation of #348 