### PR TITLE
Changed from [] slicing to .get() method

### DIFF
--- a/flood_forecast/time_model.py
+++ b/flood_forecast/time_model.py
@@ -87,10 +87,10 @@ class TimeSeriesModel(ABC):
     def wandb_init(self):
         if self.params["wandb"]:
             wandb.init(
-                project=self.params["wandb"]["project"],
+                project=self.params["wandb"].get("project"),
                 config=self.params,
-                name=self.params["wandb"]["name"],
-                tags=self.params["wandb"]["tags"])
+                name=self.params["wandb"].get("name"),
+                tags=self.params["wandb"].get("tags")),
             return True
         elif "sweep" in self.params:
             print("Using Wandb config:")


### PR DESCRIPTION
Using dict bracket [] slicing raises errors if the user has not included the params being sliced. 

One feature I like about wandb is that it automatically generates run names. I don't want to have to pass run names manually. I actually didn't know it was possible to do it!

Changing line 92 from `name=self.params["wandb"]["name"]` to `name=self.params["wandb"].get("name")` means that wandb will automatically generate a new, random name for each run and it saves the user typing. 

I changed lines 90 and 93 for the same reason. I think 93 is fine as .get() since a user won't always want to add tags. But I can see an argument for 90 staying as bracket notation as you usually want to specify a wandb project manually. 