### PR TITLE
Id support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max_line_length=120
 ignore=E305,W504, E126
-max-complexity=19
+max-complexity=18

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -193,6 +193,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
     def __make__dict__(self):
         for i in range(0, len(self.unique_cols)):
             self.unqiue_dict[self.unique_cols[i]] = i
+        print("Unique dict here")
+        print(self.unqiue_dict)
 
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -184,15 +184,15 @@ class CSVSeriesIDLoader(CSVDataLoader):
         :rtype: List
         """
         if self.return_all_series:
-            # TO-DO
             src_list = {}
             targ_list = {}
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
+                idx = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[va] = t
-                targ_list[va] = targ
+                src_list[idx] = t
+                targ_list[idx] = targ
             return src_list, targ_list
         else:
             print("s")

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -191,11 +191,11 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 targ_start_idx = idx + self.forecast_history
                 idx = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[idx] = t
-                targ_list[idx] = targ
+                src_list[int(idx)] = t
+                targ_list[int(idx)] = targ
             return src_list, targ_list
         else:
-            print("s")
+            raise NotImplementedError
         return super().__getitem__(idx)
 
     def __sample_series_id__(idx, series_id):

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -178,7 +178,6 @@ class CSVSeriesIDLoader(CSVDataLoader):
         self.listed_vals = df_list
         if return_all:
             self.__assert_same_length__()
-        self.__make__dict__()
 
     def __assert_same_length__(self):
         for item in self.listed_vals:
@@ -213,8 +212,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 # Create helper function to convert to int and stash as dict
                 idx2 = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[self.unqiue_dict[idx2]] = t[:, :-1]
-                targ_list[self.unqiue_dict[idx2]] = targ[:, :-1]
+                src_list[self.unqiue_dict[idx2]] = t
+                targ_list[self.unqiue_dict[idx2]] = targ
             return src_list, targ_list
         else:
             raise NotImplementedError

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -189,7 +189,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col].iloc[0]
+                idx2 = va[self.series_id_col][0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -191,8 +191,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 targ_start_idx = idx + self.forecast_history
                 idx2 = va[self.series_id_col].reset_index().iloc[0].values
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[int(idx2[0])] = t
-                targ_list[int(idx2[0])] = targ
+                src_list[int(idx2)] = t
+                targ_list[int(idx2)] = targ
             return src_list, targ_list
         else:
             raise NotImplementedError

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -178,7 +178,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.
 
-        :param idx: [description]
+        :param idx: The index to lookup in the dataframe
         :type idx: int
         :return: A set of dictionaries that contain the data for each series.
         :rtype: Tuple[Dict, Dict]
@@ -189,7 +189,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col].first(0)
+                idx2 = va[self.series_id_col].reset_index().iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -189,10 +189,10 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx = va[self.series_id_col].iloc[0]
+                idx2 = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[int(idx)] = t
-                targ_list[int(idx)] = targ
+                src_list[int(idx2)] = t
+                targ_list[int(idx2)] = targ
             return src_list, targ_list
         else:
             raise NotImplementedError

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -2,7 +2,7 @@ from torch.utils.data import Dataset
 import numpy as np
 import pandas as pd
 import torch
-from typing import List, Union, Optional
+from typing import Dict, Tuple, Union, Optional, List
 from flood_forecast.pre_dict import interpolate_dict
 from flood_forecast.preprocessing.buil_dataset import get_data
 from datetime import datetime
@@ -175,13 +175,13 @@ class CSVSeriesIDLoader(CSVDataLoader):
             df_list.append(self.df[self.df[self.series_id_col] == col])
         self.listed_vals = df_list
 
-    def __getitem__(self, idx: int) -> List[dict, dict]:
+    def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.
 
         :param idx: [description]
         :type idx: int
         :return: [description]
-        :rtype: List[dict, dict]
+        :rtype: List
         """
         if self.return_all_series:
             # TO-DO

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -191,8 +191,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 targ_start_idx = idx + self.forecast_history
                 idx2 = va[self.series_id_col].reset_index().iloc[0].values
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[int(idx2)] = t
-                targ_list[int(idx2)] = targ
+                src_list[int(idx2[0])] = t
+                targ_list[int(idx2[0])] = targ
             return src_list, targ_list
         else:
             raise NotImplementedError

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -189,7 +189,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col][0]
+                idx2 = va[self.series_id_col].first(0)
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -174,6 +174,12 @@ class CSVSeriesIDLoader(CSVDataLoader):
         for col in self.unique_cols:
             df_list.append(self.df[self.df[self.series_id_col] == col])
         self.listed_vals = df_list
+        if return_all:
+            self.__assert_same_length__()
+
+    def __assert_same_length__(self):
+        for item in self.listed_vals:
+            assert len(item) == len(self.listed_vals[0])
 
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -1,6 +1,7 @@
 from torch.utils.data import Dataset
 import numpy as np
 import pandas as pd
+import warnings as warning
 import torch
 from typing import Dict, Tuple, Union, Optional, List
 from flood_forecast.pre_dict import interpolate_dict
@@ -179,7 +180,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
 
     def __assert_same_length__(self):
         for item in self.listed_vals:
-            assert len(item) == len(self.listed_vals[0])
+            if len(item) != len(self.listed_vals[0]):
+                warning.warn("Warning uneven sequence lengths will likely lead to errors")
 
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -153,7 +153,7 @@ class CSVDataLoader(Dataset):
 
 class CSVSeriesIDLoader(CSVDataLoader):
     def __init__(self, series_id_col: str, main_params: dict, return_method: str, return_all=True):
-        """A da
+        """A data-loader for a CSV file that contains a series ID column.
 
         :param series_id_col: The id
         :type series_id_col: str
@@ -175,17 +175,24 @@ class CSVSeriesIDLoader(CSVDataLoader):
             df_list.append(self.df[self.df[self.series_id_col] == col])
         self.listed_vals = df_list
 
-    def __getitem__(self, idx: int):
+    def __getitem__(self, idx: int) -> List[dict, dict]:
+        """Returns a set of dictionaries that contain the data for each series.
+
+        :param idx: [description]
+        :type idx: int
+        :return: [description]
+        :rtype: List[dict, dict]
+        """
         if self.return_all_series:
             # TO-DO
-            src_list = []
-            targ_list = []
+            src_list = {}
+            targ_list = {}
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list.append(t)
-                targ_list.append(targ)
+                src_list[va] = t
+                targ_list[va] = targ
             return src_list, targ_list
         else:
             print("s")

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -191,11 +191,11 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 targ_start_idx = idx + self.forecast_history
                 idx = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[int(idx)] = t
-                targ_list[int(idx)] = targ
+                src_list[idx] = t
+                targ_list[idx] = targ
             return src_list, targ_list
         else:
-            raise NotImplementedError
+            print("s")
         return super().__getitem__(idx)
 
     def __sample_series_id__(idx, series_id):

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -169,7 +169,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
         self.series_id_col = series_id_col
         self.return_method = return_method
         self.return_all_series = return_all
-        self.unique_cols = self.original_df[series_id_col].dropna.unique().tolist()
+        self.unique_cols = self.original_df[series_id_col].dropna().unique().tolist()
         df_list = []
         for col in self.unique_cols:
             df_list.append(self.df[self.df[self.series_id_col] == col])

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -189,7 +189,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col].reset_index().iloc[0]
+                idx2 = va[self.series_id_col].reset_index().iloc[0].values
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -186,10 +186,11 @@ class CSVSeriesIDLoader(CSVDataLoader):
         if self.return_all_series:
             src_list = {}
             targ_list = {}
+            print(self.unique_cols)
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col].reset_index().iloc[0].values
+                idx2 = va[self.series_id_col].iloc[0].values[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -180,8 +180,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
 
         :param idx: [description]
         :type idx: int
-        :return: [description]
-        :rtype: List
+        :return: A set of dictionaries that contain the data for each series.
+        :rtype: Tuple[Dict, Dict]
         """
         if self.return_all_series:
             src_list = {}

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -175,6 +175,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
         df_list = []
         for col in self.unique_cols:
             df_list.append(self.df[self.df[self.series_id_col] == col])
+        self.__make__dict__()
         self.listed_vals = df_list
         if return_all:
             self.__assert_same_length__()
@@ -190,8 +191,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
         )
 
     def __make__dict__(self):
-        for i in range(0, len(self.listed_vals)):
-            self.unqiue_dict[self.listed_vals[i][self.unique_cols].iloc[0].values[0]] = i
+        for i in range(0, len(self.unique_cols)):
+            self.unqiue_dict[self.unique_cols[i]] = i
 
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -169,7 +169,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
         self.series_id_col = series_id_col
         self.return_method = return_method
         self.return_all_series = return_all
-        self.unique_cols = self.original_df[series_id_col].unique().tolist()
+        self.unique_cols = self.original_df[series_id_col].dropna.unique().tolist()
         df_list = []
         for col in self.unique_cols:
             df_list.append(self.df[self.df[self.series_id_col] == col])
@@ -190,7 +190,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
             for va in self.listed_vals:
                 t = torch.Tensor(va.iloc[idx: self.forecast_history + idx].values)
                 targ_start_idx = idx + self.forecast_history
-                idx2 = va[self.series_id_col].iloc[0].values[0]
+                idx2 = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
                 src_list[int(idx2)] = t
                 targ_list[int(idx2)] = targ

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -181,7 +181,12 @@ class CSVSeriesIDLoader(CSVDataLoader):
     def __assert_same_length__(self):
         for item in self.listed_vals:
             if len(item) != len(self.listed_vals[0]):
-                warning.warn("Warning uneven sequence lengths will likely lead to errors")
+                warning.warn("Warning uneven sequence lengths will likely lead to errors and incorrect sequences")
+
+    def __len__(self) -> int:
+        return (
+            len(self.listed_vals[0].index) - self.forecast_history - self.forecast_length - 1
+        )
 
     def __getitem__(self, idx: int) -> Tuple[Dict, Dict]:
         """Returns a set of dictionaries that contain the data for each series.

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -178,6 +178,7 @@ class CSVSeriesIDLoader(CSVDataLoader):
         self.listed_vals = df_list
         if return_all:
             self.__assert_same_length__()
+        self.__make__dict__()
 
     def __assert_same_length__(self):
         for item in self.listed_vals:
@@ -212,8 +213,8 @@ class CSVSeriesIDLoader(CSVDataLoader):
                 # Create helper function to convert to int and stash as dict
                 idx2 = va[self.series_id_col].iloc[0]
                 targ = torch.Tensor(va.iloc[targ_start_idx: targ_start_idx + self.forecast_length].to_numpy())
-                src_list[self.unqiue_dict[idx2]] = t
-                targ_list[self.unqiue_dict[idx2]] = targ
+                src_list[self.unqiue_dict[idx2]] = t[:, :-1]
+                targ_list[self.unqiue_dict[idx2]] = targ[:, :-1]
             return src_list, targ_list
         else:
             raise NotImplementedError

--- a/flood_forecast/preprocessing/temporal_feats.py
+++ b/flood_forecast/preprocessing/temporal_feats.py
@@ -25,7 +25,7 @@ def create_feature(key: str, value: str, df: pd.DataFrame, dt_column: str):
     """Function to create temporal features
         Uses dict to make val.
     :param key: The datetime feature you would like to create
-    :type key: str s
+    :type key: str
     :param value: The type of feature you would like to create (cyclical or numerical)
     :type value: str
     :param df: The Pandas dataframe with the datetime

--- a/flood_forecast/preprocessing/temporal_feats.py
+++ b/flood_forecast/preprocessing/temporal_feats.py
@@ -10,7 +10,7 @@ def make_temporal_features(features_list: Dict, dt_column: str, df: pd.DataFrame
     :type features_list: Dict
     :param dt_column: [description]
     :type dt_column: str
-    :param df: [description]
+    :param df: The end data-frame
     :type df: pd.DataFrame
     :return: The DF with several new columns added
     :rtype: pd.DataFrame

--- a/flood_forecast/preprocessing/temporal_feats.py
+++ b/flood_forecast/preprocessing/temporal_feats.py
@@ -25,7 +25,7 @@ def create_feature(key: str, value: str, df: pd.DataFrame, dt_column: str):
     """Function to create temporal features
         Uses dict to make val.
     :param key: The datetime feature you would like to create
-    :type key: str
+    :type key: str s
     :param value: The type of feature you would like to create (cyclical or numerical)
     :type value: str
     :param df: The Pandas dataframe with the datetime

--- a/flood_forecast/pytorch_training.py
+++ b/flood_forecast/pytorch_training.py
@@ -15,7 +15,6 @@ from flood_forecast.custom.custom_opt import GaussianLoss, MASELoss
 
 def handle_meta_data(model: PyTorchForecast):
     """A function to init models with meta-data
-    s
     :param model: A PyTorchForecast model with meta_data parameter block in config file.
     :type model: PyTorchForecast
     :return: Returns a tuple of the initial meta-representationf
@@ -228,11 +227,11 @@ def compute_loss(labels, output, src, criterion, validation_dataset, probabilist
     :param src: The source values (only really needed for the MASELoss function)
     :type src: torch.Tensor
     :param criterion: [description]
-    :type criterion: [type]
+    :type criterion: torch.nn.Loss or some variation
     :param validation_dataset: Only passed when unscaling of data is needed.
     :type validation_dataset: torch.utils.data.dataset
     :param probabilistic: Whether the model is a probabalistic returns a distribution, defaults to None
-    :type probabilistic: [type], optional
+    :type probabilistic: bool, optional
     :param output_std: The standard distribution, defaults to None
     :type output_std: [type], optional
     :param m: The number of targets defaults to 1
@@ -314,6 +313,8 @@ def torch_single_train(model: PyTorchForecast,
             src = src[0]
             # Assign to avoid other if statement
             trg = trg[0]
+        elif "SeriesIDLoader" == model.params["dataset_params"]["class"]:
+            pass
         src = src.to(model.device)
         trg = trg.to(model.device)
         output = model.model(src, **forward_params)

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -5,8 +5,8 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     :type src: torch.Tensor
     :param trg: A dictionary of target sequences(partitioned by series_id)
     :type trg: torch.Tensor
-    :param model: A model that takes both a src and a series_id
-    :type model: [type]
+    :param model: A model that takes both a src and a series_id as paramaete
+    :type model: PyTorchForecastModel
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -5,8 +5,8 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     :type src: torch.Tensor
     :param trg: A dictionary of target sequences(partitioned by series_id)
     :type trg: torch.Tensor
-    :param model: A model that takes both a src and a series_id as paramaete
-    :type model: PyTorchForecastModel
+    :param model: A model that takes both a src and a series_id
+    :type model: [type]
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -1,0 +1,2 @@
+def handle_csv_id_output(src, trg, model):
+    pass

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -1,2 +1,16 @@
-def handle_csv_id_output(src, trg, model):
-    pass
+def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
+    """A helper function to better handle the output of models with a series_id
+
+    :param src: A list of src sequences
+    :type src: torch.Tensor
+    :param trg: A list of target sequences
+    :type trg: torch.Tensor
+    :param model: A model that takes both a src and a series_id
+    :type model: [type]
+    """
+    total_loss = 0
+    for (k, v), (k2, v2) in zip(src.items(), trg.items()):
+        output = model(k, v)
+        loss = criterion(output, v2)
+        total_loss += loss.item()
+    total_loss /= len(src.keys())

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -5,12 +5,12 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     :type src: torch.Tensor
     :param trg: A dictionary of target sequences(partitioned by series_id)
     :type trg: torch.Tensor
-    :param model: A model that takes both a src and a series_id
-    :type model: [type]
+    :param model: A model that takes both a src and a series_id as paramaete
+    :type model: PyTorchForecastModel
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):
-        output = model(v, k)
+        output = model(v, int(k))
         loss = criterion(output, v2)
         total_loss += loss.item()
     total_loss /= len(src.keys())

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -5,12 +5,12 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     :type src: torch.Tensor
     :param trg: A dictionary of target sequences(partitioned by series_id)
     :type trg: torch.Tensor
-    :param model: A model that takes both a src and a series_id as paramaete
-    :type model: PyTorchForecastModel
+    :param model: A model that takes both a src and a series_id
+    :type model: [type]
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):
-        output = model(v, int(k))
+        output = model(v, k)
         loss = criterion(output, v2)
         total_loss += loss.item()
     total_loss /= len(src.keys())

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -1,14 +1,14 @@
 def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     """A helper function to better handle the output of models with a series_id
 
-    :param src: A list of src sequences
+    :param src: A dictionary of src sequences (partitioned by series_id)
     :type src: torch.Tensor
-    :param trg: A list of target sequences
+    :param trg: A dictionary of target sequences(partitioned by series_id)
     :type trg: torch.Tensor
     :param model: A model that takes both a src and a series_id
     :type model: [type]
     """
-    total_loss = 0
+    total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):
         output = model(k, v)
         loss = criterion(output, v2)

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -10,7 +10,7 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):
-        output = model(k, v)
+        output = model(v, k)
         loss = criterion(output, v2)
         total_loss += loss.item()
     total_loss /= len(src.keys())

--- a/flood_forecast/series_id_helper.py
+++ b/flood_forecast/series_id_helper.py
@@ -10,7 +10,7 @@ def handle_csv_id_output(src, trg, model, criterion, random_sample=False):
     """
     total_loss = 0.0
     for (k, v), (k2, v2) in zip(src.items(), trg.items()):
-        output = model(v, k)
+        output = model(k, v)
         loss = criterion(output, v2)
         total_loss += loss.item()
     total_loss /= len(src.keys())

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -256,7 +256,7 @@ class TransformerModel(nn.Module):
 
         :param series_id:   ID of the time series
         :type series_id: int
-        :param x: [description]
+        :param x: Tensor of shape (batch_size, seq_len, n_time_series)
         :type x: torch.Tensor
         :return: [description]
         :rtype: [type]

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -267,7 +267,7 @@ class TransformerModel(nn.Module):
         if self.seq_num:
             embedding_sum = torch.zeros(batch_size, length)
             embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
-            embedding_sum = self.id_embed(embedding_sum)
+            embedding_sum = self.id_embed(embedding_sum).type(torch.LongTensor)
         print("shape below")
         print(embedding_sum.shape)
         print(x.shape)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -298,8 +298,8 @@ class DecoderTransformer(nn.Module):
             additional_params: Additional parameters used to initalize the attention model. Can inc
         """
         super(DecoderTransformer, self).__init__()
-        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd,
-                                            forecast_history, dropout, scale_att, q_len, additional_params)
+        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd, forecast_history,
+                                            dropout, scale_att, q_len, additional_params, seq_num=seq_num)
         self.softplus = nn.Softplus()
         self.mu = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)
         self.sigma = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -266,7 +266,7 @@ class TransformerModel(nn.Module):
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
         if self.seq_num:
             embedding_sum = torch.zeros(batch_size, length)
-            embedding_sum.fill_(series_id)
+            embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
             embedding_sum = self.id_embed(embedding_sum)
         print("shape below")
         print(embedding_sum.shape)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -265,8 +265,9 @@ class TransformerModel(nn.Module):
         length = x.size(1)  # (Batch_size, length, input_dim)
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
         if self.seq_num:
-            id_embedding = self.id_embed(series_id)
-            embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
+            embedding_sum = torch.zeros(batch_size, length).to(self.device)
+            embedding_sum = embedding_sum._fill(series_id)
+            embedding_sum = self.id_embed(embedding_sum)
         print("shape below")
         print(embedding_sum.shape)
         print(x.shape)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -266,7 +266,7 @@ class TransformerModel(nn.Module):
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
         if self.seq_num:
             embedding_sum = torch.zeros(batch_size, length)
-            embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
+            embedding_sum = embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
             embedding_sum = self.id_embed(embedding_sum).type(torch.LongTensor)
         print("shape below")
         print(embedding_sum.shape)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -265,8 +265,9 @@ class TransformerModel(nn.Module):
         length = x.size(1)  # (Batch_size, length, input_dim)
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
         if self.seq_num:
-            id_embedding = self.id_embed(series_id)
-            embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
+            embedding_sum = torch.zeros(batch_size, length)
+            embedding_sum.fill_(series_id)
+            embedding_sum = self.id_embed(embedding_sum)
         print("shape below")
         print(embedding_sum.shape)
         print(x.shape)
@@ -297,8 +298,8 @@ class DecoderTransformer(nn.Module):
             additional_params: Additional parameters used to initalize the attention model. Can inc
         """
         super(DecoderTransformer, self).__init__()
-        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd,
-                                            forecast_history, dropout, scale_att, q_len, additional_params)
+        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd, forecast_history,
+                                            dropout, scale_att, q_len, additional_params, seq_num=seq_num)
         self.softplus = nn.Softplus()
         self.mu = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)
         self.sigma = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -265,9 +265,8 @@ class TransformerModel(nn.Module):
         length = x.size(1)  # (Batch_size, length, input_dim)
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
         if self.seq_num:
-            embedding_sum = torch.zeros(batch_size, length).to(self.device)
-            embedding_sum = embedding_sum._fill(series_id)
-            embedding_sum = self.id_embed(embedding_sum)
+            id_embedding = self.id_embed(series_id)
+            embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
         print("shape below")
         print(embedding_sum.shape)
         print(x.shape)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -258,6 +258,7 @@ class TransformerModel(nn.Module):
         if self.seq_num:
             id_embedding = self.id_embed(series_id)
             embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
+        print("shape below")
         print(embedding_sum.shape)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)
         po_embedding = self.po_embed(position)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -258,6 +258,7 @@ class TransformerModel(nn.Module):
         if self.seq_num:
             id_embedding = self.id_embed(series_id)
             embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
+        print(embedding_sum.shape)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)
         po_embedding = self.po_embed(position)
         embedding_sum[:] = po_embedding

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -28,7 +28,6 @@ SOFTWARE.
 # Arxiv Link https://arxiv.org/pdf/1907.00235.pdf
 
 
-from pandas.core import series
 import numpy as np
 import torch
 import torch.nn as nn
@@ -270,7 +269,6 @@ class TransformerModel(nn.Module):
             embedding_sum = embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
             embedding_sum = self.id_embed(embedding_sum).type(torch.LongTensor)
         print("shape below")
-        print(series_id)
         print(embedding_sum.shape)
         print(x.shape)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -271,6 +271,7 @@ class TransformerModel(nn.Module):
         print("shape below")
         print(embedding_sum.shape)
         print(x.shape)
+        print(self.seq_num)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)
         po_embedding = self.po_embed(position)
         embedding_sum[:] = po_embedding

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -298,8 +298,8 @@ class DecoderTransformer(nn.Module):
             additional_params: Additional parameters used to initalize the attention model. Can inc
         """
         super(DecoderTransformer, self).__init__()
-        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd, forecast_history,
-                                            dropout, scale_att, q_len, additional_params, seq_num=seq_num)
+        self.transformer = TransformerModel(n_time_series, n_head, sub_len, num_layer, n_embd,
+                                            forecast_history, dropout, scale_att, q_len, additional_params)
         self.softplus = nn.Softplus()
         self.mu = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)
         self.sigma = torch.nn.Linear(n_time_series + n_embd, 1, bias=True)

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -252,6 +252,15 @@ class TransformerModel(nn.Module):
         nn.init.normal_(self.po_embed.weight, std=0.02)
 
     def forward(self, series_id: int, x: torch.Tensor):
+        """Runs  forward pass of the DecoderTransformer model.
+
+        :param series_id:   ID of the time series
+        :type series_id: int
+        :param x: [description]
+        :type x: torch.Tensor
+        :return: [description]
+        :rtype: [type]
+        """
         batch_size = x.size(0)
         length = x.size(1)  # (Batch_size, length, input_dim)
         embedding_sum = torch.zeros(batch_size, length, self.n_embd).to(self.device)
@@ -260,6 +269,7 @@ class TransformerModel(nn.Module):
             embedding_sum = embedding_sum + id_embedding.unsqueeze(1)
         print("shape below")
         print(embedding_sum.shape)
+        print(x.shape)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)
         po_embedding = self.po_embed(position)
         embedding_sum[:] = po_embedding

--- a/flood_forecast/transformer_xl/transformer_bottleneck.py
+++ b/flood_forecast/transformer_xl/transformer_bottleneck.py
@@ -28,6 +28,7 @@ SOFTWARE.
 # Arxiv Link https://arxiv.org/pdf/1907.00235.pdf
 
 
+from pandas.core import series
 import numpy as np
 import torch
 import torch.nn as nn
@@ -269,6 +270,7 @@ class TransformerModel(nn.Module):
             embedding_sum = embedding_sum.fill_(series_id).type(torch.LongTensor).to(self.device)
             embedding_sum = self.id_embed(embedding_sum).type(torch.LongTensor)
         print("shape below")
+        print(series_id)
         print(embedding_sum.shape)
         print(x.shape)
         position = torch.tensor(torch.arange(length), dtype=torch.long).to(self.device)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -10,6 +10,8 @@ class TestInterpolationCode(unittest.TestCase):
         self.df = pd.read_csv(file_path)
 
     def test_back_forward(self):
+        """Test the generation of forward and backward data
+        """
         df = back_forward_generic(self.df, ["NumberOfAnimals"])
         self.assertEqual(df.iloc[3]["NumberOfAnimals"], 165)
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -27,14 +27,14 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
         self.assertGreater(x[0][0, 0], 1)
+        print(y)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method
         """
-        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, seq_num=True)
+        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=True)
         x, y = self.data_loader[0]
         l1 = handle_csv_id_output(x, y, d)
-        print(l1)
         self.assertGreater(l1, 0)
 
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -33,10 +33,8 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         """Tests the handle_series_id method
         """
         mse1 = MSELoss()
-        x, y = self.data_loader[0]
-        # add batch size to the input
-        x = x.unsqueeze(0)
         d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=3)
+        x, y = self.data_loader[0]
         l1 = handle_csv_id_output(x, y, d, mse1)
         self.assertGreater(l1, 0)
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -2,6 +2,7 @@ from flood_forecast.preprocessing.pytorch_loaders import CSVSeriesIDLoader
 import unittest
 import os
 from torch.nn import MSELoss
+from torch.utils.data import DataLoader
 from flood_forecast.series_id_helper import handle_csv_id_output
 from flood_forecast.model_dict_function import DecoderTransformer
 
@@ -33,8 +34,9 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         """Tests the handle_series_id method
         """
         mse1 = MSELoss()
+        d1 = DataLoader(self.data_loader, batch_size=2)
         d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=3)
-        x, y = self.data_loader[0]
+        x, y = d1.__iter__().__next__()
         l1 = handle_csv_id_output(x, y, d, mse1)
         self.assertGreater(l1, 0)
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -27,8 +27,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         x, y = self.data_loader[0]
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
-        self.assertGreater(x[0][0, 0], 1)
-        print(y)
+        self.assertGreater(x[2][0, 0], 1)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -1,6 +1,7 @@
 from flood_forecast.preprocessing.pytorch_loaders import CSVSeriesIDLoader
 import unittest
 import os
+from torch.nn import MSELoss
 from flood_forecast.series_id_helper import handle_csv_id_output
 from flood_forecast.model_dict_function import DecoderTransformer
 
@@ -32,9 +33,10 @@ class TestInterpolationCSVLoader(unittest.TestCase):
     def test_handle_series_id(self):
         """Tests the handle_series_id method
         """
+        mse1 = MSELoss()
         d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=True)
         x, y = self.data_loader[0]
-        l1 = handle_csv_id_output(x, y, d)
+        l1 = handle_csv_id_output(x, y, d, mse1)
         self.assertGreater(l1, 0)
 
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -34,7 +34,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         """Tests the handle_series_id method
         """
         mse1 = MSELoss()
-        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=True)
+        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=3)
         x, y = self.data_loader[0]
         l1 = handle_csv_id_output(x, y, d, mse1)
         self.assertGreater(l1, 0)

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -15,7 +15,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.dataset_params = {
             "file_path": os.path.join(self.test_data_path, "test2.csv"),
             "forecast_history": 20,
-            "forecast_length": 10,
+            "forecast_length": 1,
             "relevant_cols": ["vel", "obs", "day_of_week"],
             "target_col": ["vel"],
             "interpolate_param": False,

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -34,6 +34,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, seq_num=True)
         x, y = self.data_loader[0]
         l1 = handle_csv_id_output(x, y, d)
+        print(l1)
         self.assertGreater(l1, 0)
 
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -1,6 +1,8 @@
 from flood_forecast.preprocessing.pytorch_loaders import CSVSeriesIDLoader
 import unittest
 import os
+from flood_forecast.series_id_helper import handle_csv_id_output
+from flood_forecast.model_dict_function import DecoderTransformer
 
 
 class TestInterpolationCSVLoader(unittest.TestCase):
@@ -22,9 +24,18 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         """Tests the series_id method for one
         """
         x, y = self.data_loader[0]
-        self.assertIsInstance(x, list)
-        self.assertIsInstance(y, list)
+        self.assertIsInstance(x, dict)
+        self.assertIsInstance(y, dict)
         self.assertGreater(x[0][0, 0], 1)
+
+    def test_handle_series_id(self):
+        """Tests the handle_series_id method
+        """
+        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, seq_num=True)
+        x, y = self.data_loader[0]
+        l1 = handle_csv_id_output(x, y, d)
+        self.assertGreater(l1, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -29,6 +29,8 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
         self.assertGreater(x[2][0, 0], 1)
+        self.assertEqual(x[1].shape[1], 3)
+        self.assertEqual(y[1].shape[1], 3)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -29,8 +29,6 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
         self.assertGreater(x[2][0, 0], 1)
-        self.assertEqual(x[1].shape[1], 3)
-        self.assertEqual(y[1].shape[1], 3)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -29,6 +29,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
         self.assertGreater(x[2][0, 0], 1)
+        self.assertEqual(x[2].shape[2], 3)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -33,8 +33,10 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         """Tests the handle_series_id method
         """
         mse1 = MSELoss()
-        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=3)
         x, y = self.data_loader[0]
+        # add batch size to the input
+        x = x.unsqueeze(0)
+        d = DecoderTransformer(10, 8, 4, 128, 10, 0.2, 1, {}, seq_num=3)
         l1 = handle_csv_id_output(x, y, d, mse1)
         self.assertGreater(l1, 0)
 

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -29,7 +29,8 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.assertIsInstance(x, dict)
         self.assertIsInstance(y, dict)
         self.assertGreater(x[2][0, 0], 1)
-        self.assertEqual(x[2].shape[2], 3)
+        print(x[2].shape)
+        self.assertEqual(x[2].shape[1], 3)
 
     def test_handle_series_id(self):
         """Tests the handle_series_id method

--- a/tests/test_series_id.py
+++ b/tests/test_series_id.py
@@ -15,7 +15,7 @@ class TestInterpolationCSVLoader(unittest.TestCase):
         self.dataset_params = {
             "file_path": os.path.join(self.test_data_path, "test2.csv"),
             "forecast_history": 20,
-            "forecast_length": 20,
+            "forecast_length": 10,
             "relevant_cols": ["vel", "obs", "day_of_week"],
             "target_col": ["vel"],
             "interpolate_param": False,


### PR DESCRIPTION
This PR aims to accomplish the following things

- [ ] Provide end-to-end support for series_id with the TransformerDecoder model for evenly lengthed times series
- [ ] Provide adequate test coverage of TransformerDecoder 
- [ ] Provide a skelton for interpolating missing values in time series ids 
- [ ] Outline a shuffle method to shuffle series id and return at diff int