### PR TITLE
add support for taking raw df

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflows will upload a Python Package using Twine when a release is created (must bump version)
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package

--- a/flood_forecast/deployment/inference.py
+++ b/flood_forecast/deployment/inference.py
@@ -47,7 +47,7 @@ class InferenceMode(object):
             wandb.config.update(model_params, allow_val_change=True)
 
     def infer_now(self, some_date: datetime, csv_path=None, save_buck=None, save_name=None, use_torch_script=False):
-        """Performs inference on a CSV file at a specified datatime
+        """Performs inference on a CSV file at a specified date-time
 
         :param some_date: The date you want inference to begin on.
         :param csv_path: A path to a CSV you want to perform inference on, defaults to None

--- a/flood_forecast/deployment/inference.py
+++ b/flood_forecast/deployment/inference.py
@@ -25,7 +25,7 @@ class InferenceMode(object):
         :type model_params: Dict
         :param csv_path: Path to the CSV test file you want to be used for inference or a Pandas dataframe.
         :type csv_path: str
-        :param weight_path: Path to the model weights
+        :param weight_path: Path to the model weights (.pth file)
         :type weight_path: str
         :param wandb_proj: The name of the WB project leave blank if you don't want to log to Wandb, defaults to None
         :type wandb_proj: str, optionals
@@ -92,14 +92,14 @@ class InferenceMode(object):
 
         :param date: The datetime to start inference
         :type date: datetime
-        :param csv_path: The path to the CSV file you want to use for inference, defaults to None
+        :param csv_path: The path to the CSV file or  you want to use for inference, defaults to None
         :type csv_path: str, optional
-        :param csv_bucket: [description], defaults to None
+        :param csv_bucket: The bucket where the CSV file is located, defaults to None
         :type csv_bucket: str, optional
-        :param save_name: [description], defaults to None
-        :type save_name: [type], optional
-        :param wandb_plot_id: [description], defaults to None
-        :type wandb_plot_id: [type], optional
+        :param save_name: Where to save the output csv, defaults to None
+        :type save_name: str, optional
+        :param wandb_plot_id: The id to save wandb plot as on dashboard, defaults to None
+        :type wandb_plot_id: str, optional
         :return: [description]
         :rtype: tuple(torch.Tensor, torch.Tensor, CSVTestLoader, matplotlib.pyplot.plot)
         """

--- a/flood_forecast/deployment/inference.py
+++ b/flood_forecast/deployment/inference.py
@@ -8,10 +8,12 @@ from flood_forecast.gcp_integration.basic_utils import upload_file
 from datetime import datetime
 import wandb
 import torch
+from typing import Union
+import pandas as pd
 
 
 class InferenceMode(object):
-    def __init__(self, forecast_steps: int, num_prediction_samples: int, model_params, csv_path: str, weight_path,
+    def __init__(self, forecast_steps: int, n_samp: int, model_params, csv_path: Union[str, pd.DataFrame], weight_path,
                  wandb_proj: str = None, torch_script=False):
         """Class to handle inference for models,
 
@@ -21,7 +23,7 @@ class InferenceMode(object):
         :type num_prediction_samples: int
         :param model_params: A dictionary of model parameters (ideally this should come from saved JSON config file)
         :type model_params: Dict
-        :param csv_path: Path to the CSV test file you want to be used for inference. Evem of you aren't using
+        :param csv_path: Path to the CSV test file you want to be used for inference or a Pandas dataframe.
         :type csv_path: str
         :param weight_path: Path to the model weights
         :type weight_path: str
@@ -38,7 +40,7 @@ class InferenceMode(object):
             s = scaling_function({}, self.inference_params["dataset_params"])["scaling"]
             self.inference_params["dataset_params"]["scaling"] = s
         self.inference_params["hours_to_forecast"] = forecast_steps
-        self.inference_params["num_prediction_samples"] = num_prediction_samples
+        self.inference_params["num_prediction_samples"] = n_samp
         if wandb_proj:
             date = datetime.now()
             wandb.init(name=date.strftime("%H-%M-%D-%Y") + "_prod", project=wandb_proj)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -2,8 +2,6 @@ import os
 import re
 from typing import Optional
 from pathlib import Path
-
-from isort import file
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
     process_asos_data,
@@ -195,4 +193,4 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
         )
         return pd.read_csv(str(local_temp_filepath))
     else:
-        return pd.read_csv(file_path)
+        return  pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
@@ -158,7 +158,7 @@ def create_usgs(meta_data_dir: str, precip_path: str, start: int, end: int):
             )
 
 
-def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
+def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> Union[pd.DataFrame, str]:
     """Extract bucket name and storage object name from file_path
     Args:
         file_path (str): [description]
@@ -193,5 +193,7 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
         if str(local_temp_filepath)[-3:] != "csv":
             return local_temp_filepath
         return pd.read_csv(str(local_temp_filepath))
-    else:
-        return pd.read_csv(file_path)
+    elif file_path != "csv":
+        return file_path
+    return pd.read_csv(file_path)
+    

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
@@ -158,7 +158,7 @@ def create_usgs(meta_data_dir: str, precip_path: str, start: int, end: int):
             )
 
 
-def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
+def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> Union[str, pd.DataFrame]:
     """Extract bucket name and storage object name from file_path
     Args:
         file_path (str): [description]
@@ -193,5 +193,6 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
         if str(local_temp_filepath)[-3:] != "csv":
             return local_temp_filepath
         return pd.read_csv(str(local_temp_filepath))
-    else:
-        return pd.read_csv(file_path)
+    elif str(file_path)[-3:] != "csv":
+        file_path
+    return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -2,6 +2,8 @@ import os
 import re
 from typing import Optional
 from pathlib import Path
+
+from isort import file
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
     process_asos_data,
@@ -193,4 +195,4 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
         )
         return pd.read_csv(str(local_temp_filepath))
     else:
-        return  pd.read_csv(file_path)
+        return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -2,8 +2,6 @@ import os
 import re
 from typing import Optional
 from pathlib import Path
-
-from isort import file
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
     process_asos_data,
@@ -18,7 +16,6 @@ from flood_forecast.gcp_integration.basic_utils import (
     download_file,
 )
 from flood_forecast.preprocessing.eco_gage_set import eco_gage_set
-
 import json
 from datetime import datetime
 import pytz

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -190,6 +190,8 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
             destination_file_name=local_temp_filepath,
             service_key_path=gcp_service_key,
         )
+        if str(local_temp_filepath)[-3:] != "csv":
+            return local_temp_filepath
         return pd.read_csv(str(local_temp_filepath))
     else:
         return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Optional, Union
+from typing import Optional
 from pathlib import Path
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
@@ -158,7 +158,7 @@ def create_usgs(meta_data_dir: str, precip_path: str, start: int, end: int):
             )
 
 
-def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> Union[pd.DataFrame, str]:
+def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
     """Extract bucket name and storage object name from file_path
     Args:
         file_path (str): [description]
@@ -193,7 +193,5 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> Union[pd.
         if str(local_temp_filepath)[-3:] != "csv":
             return local_temp_filepath
         return pd.read_csv(str(local_temp_filepath))
-    elif file_path != "csv":
-        return file_path
-    return pd.read_csv(file_path)
-    
+    else:
+        return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -194,5 +194,5 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> Union[str
             return local_temp_filepath
         return pd.read_csv(str(local_temp_filepath))
     elif str(file_path)[-3:] != "csv":
-        file_path
+        return file_path
     return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/buil_dataset.py
+++ b/flood_forecast/preprocessing/buil_dataset.py
@@ -2,6 +2,8 @@ import os
 import re
 from typing import Optional
 from pathlib import Path
+
+from isort import file
 from flood_forecast.preprocessing.closest_station import (
     get_weather_data,
     process_asos_data,
@@ -173,6 +175,8 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
     Returns:
         str: local file name
     """
+    if isinstance(file_path, pd.DataFrame):
+        return file_path
     if file_path.startswith("gs://"):
         # download data from gcs to local
         print(file_path)
@@ -189,6 +193,6 @@ def get_data(file_path: str, gcp_service_key: Optional[str] = None) -> str:
             destination_file_name=local_temp_filepath,
             service_key_path=gcp_service_key,
         )
-        return str(local_temp_filepath)
+        return pd.read_csv(str(local_temp_filepath))
     else:
-        return file_path
+        return pd.read_csv(file_path)

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -30,7 +30,7 @@ class CSVDataLoader(Dataset):
     ):
         """
         A data loader that takes a CSV file and properly batches for use in training/eval a PyTorch model
-        :param file_path: The path to the CSV file you wish to use.
+        :param file_path: The path to the CSV file you wish to use (GCS compatible).
         :param forecast_history: This is the length of the historical time series data you wish to
                                 utilize for forecasting
         :param forecast_length: The number of time steps to forecast ahead (for transformer this must
@@ -223,7 +223,7 @@ class CSVTestLoader(CSVDataLoader):
         **kwargs
     ):
         """
-        :param str df_path:
+        :param str df_path: The path to the CSV file you want to use (GCS compatible) or a Pandas DataFrame
         A data loader for the test data.
         """
         if "file_path" not in kwargs:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -54,8 +54,11 @@ class CSVDataLoader(Dataset):
         self.forecast_history = forecast_history
         self.forecast_length = forecast_length
         print("interpolate should be below")
-        self.local_file_path = get_data(file_path, gcp_service_key)
-        df = pd.read_csv(self.local_file_path)
+        if isinstance(file_path, str):
+            self.local_file_path = get_data(file_path, gcp_service_key)
+            df = pd.read_csv(self.local_file_path)
+        else:
+            df = file_path
         relevant_cols3 = []
         if sort_column:
             df[sort_column] = df[sort_column].astype("datetime64[ns]")
@@ -230,8 +233,11 @@ class CSVTestLoader(CSVDataLoader):
         if "file_path" not in kwargs:
             kwargs["file_path"] = df_path
         super().__init__(**kwargs)
-        df_path = get_data(df_path)
-        self.original_df = pd.read_csv(df_path)
+        if isinstance(df_path, str):
+            df_path = get_data(df_path)
+            self.original_df = pd.read_csv(df_path)
+        else:
+            self.original_df = df_path
         if interpolate:
             self.original_df = interpolate_dict[interpolate["method"]](self.original_df, **interpolate["params"])
         if sort_column_clone:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -54,11 +54,7 @@ class CSVDataLoader(Dataset):
         self.forecast_history = forecast_history
         self.forecast_length = forecast_length
         print("interpolate should be below")
-        if isinstance(file_path, str):
-            self.local_file_path = get_data(file_path, gcp_service_key)
-            df = pd.read_csv(self.local_file_path)
-        else:
-            df = file_path
+        df = get_data(file_path)
         relevant_cols3 = []
         if sort_column:
             df[sort_column] = df[sort_column].astype("datetime64[ns]")
@@ -233,11 +229,8 @@ class CSVTestLoader(CSVDataLoader):
         if "file_path" not in kwargs:
             kwargs["file_path"] = df_path
         super().__init__(**kwargs)
-        if isinstance(df_path, str):
-            df_path = get_data(df_path)
-            self.original_df = pd.read_csv(df_path)
-        else:
-            self.original_df = df_path
+        df_path1 = df_path
+        self.original_df = get_data(df_path1)
         if interpolate:
             self.original_df = interpolate_dict[interpolate["method"]](self.original_df, **interpolate["params"])
         if sort_column_clone:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -223,7 +223,7 @@ class CSVTestLoader(CSVDataLoader):
         **kwargs
     ):
         """
-        :param str df_path:
+        :param str df_path: The path to the CSV file you wish to use or a pandas data-frame .
         A data loader for the test data.
         """
         if "file_path" not in kwargs:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -223,7 +223,7 @@ class CSVTestLoader(CSVDataLoader):
         **kwargs
     ):
         """
-        :param str df_path: The path to the CSV file you wish to use or a pandas data-frame .
+        :param str df_path:
         A data loader for the test data.
         """
         if "file_path" not in kwargs:

--- a/flood_forecast/preprocessing/pytorch_loaders.py
+++ b/flood_forecast/preprocessing/pytorch_loaders.py
@@ -30,7 +30,7 @@ class CSVDataLoader(Dataset):
     ):
         """
         A data loader that takes a CSV file and properly batches for use in training/eval a PyTorch model
-        :param file_path: The path to the CSV file you wish to use (GCS compatible).
+        :param file_path: The path to the CSV file you wish to use (GCS compatible) or a Pandas dataframe.
         :param forecast_history: This is the length of the historical time series data you wish to
                                 utilize for forecasting
         :param forecast_length: The number of time steps to forecast ahead (for transformer this must

--- a/flood_forecast/utils.py
+++ b/flood_forecast/utils.py
@@ -9,7 +9,7 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 def numpy_to_tvar(x) -> torch.autograd.Variable:
     """ Converts a  numpy array into a PyTorch Tensor
 
-    :param x: A numpy array you want to convert
+    :param x: A numpy array you want to convert to a tensor
     :type x: torch.Tensor
     :return: A tensor variable
     :rtype: torch.Variable

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dev_requirements = [
 
 setup(
     name='flood_forecast',
-    version='0.993dev',
+    version='0.995dev',
     packages=[
         'flood_forecast',
         'flood_forecast.transformer_xl',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dev_requirements = [
 
 setup(
     name='flood_forecast',
-    version='0.994dev',
+    version='0.9944dev',
     packages=[
         'flood_forecast',
         'flood_forecast.transformer_xl',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dev_requirements = [
 
 setup(
     name='flood_forecast',
-    version='0.993dev',
+    version='0.994dev',
     packages=[
         'flood_forecast',
         'flood_forecast.transformer_xl',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dev_requirements = [
 
 setup(
     name='flood_forecast',
-    version='0.995dev',
+    version='0.993dev',
     packages=[
         'flood_forecast',
         'flood_forecast.transformer_xl',

--- a/tests/data_format_tests.py
+++ b/tests/data_format_tests.py
@@ -46,7 +46,7 @@ class DataQualityTests(unittest.TestCase):
             "station={}&data=tmpf&data=p01m&year1=2019&month1=1&day1=1&year2=2019&month2=1&"
             "day2=2&tz=Etc%2FUTC&format=onlycomma&latlon=no&missing=M&trace=T&direct=no&report_type=1&report_type=2"
         )
-        print(url)
+
         get_weather_data(os.path.join(self.test_data_path, "full_out.json"), {}, url)
         self.assertEqual(1, 1)
 

--- a/tests/data_format_tests.py
+++ b/tests/data_format_tests.py
@@ -46,7 +46,7 @@ class DataQualityTests(unittest.TestCase):
             "station={}&data=tmpf&data=p01m&year1=2019&month1=1&day1=1&year2=2019&month2=1&"
             "day2=2&tz=Etc%2FUTC&format=onlycomma&latlon=no&missing=M&trace=T&direct=no&report_type=1&report_type=2"
         )
-
+        print(url)
         get_weather_data(os.path.join(self.test_data_path, "full_out.json"), {}, url)
         self.assertEqual(1, 1)
 

--- a/tests/data_loader_tests.py
+++ b/tests/data_loader_tests.py
@@ -1,3 +1,4 @@
+from cgi import test
 from flood_forecast.preprocessing.pytorch_loaders import (
     CSVTestLoader,
     CSVDataLoader,
@@ -79,10 +80,7 @@ class DataLoaderTests(unittest.TestCase):
             gcp_service_key=None,  # for CircleCI tests, local test needs key.json
         )
 
-        self.assertEqual(
-            test_loader.local_file_path,
-            "data/flow_datasets/Afghanistan____.csv",
-        )
+        self.assertTrue(test_loader)
 
     def test_ae(self):
         x, y = self.ae_loader[0]
@@ -93,7 +91,7 @@ class DataLoaderTests(unittest.TestCase):
         self.assertEqual(x.shape[0], 30)
         self.assertEqual(x.shape[1], 3)
         self.assertEqual(y.shape[0], 20)
-        # Check first and last dim are not overlap
+        # Check first and last dim are not overlapping
         self.assertFalse(torch.eq(x[29, 0], y[0, 0]))
 
     def test_start_end(self):

--- a/tests/data_loader_tests.py
+++ b/tests/data_loader_tests.py
@@ -1,4 +1,3 @@
-from cgi import test
 from flood_forecast.preprocessing.pytorch_loaders import (
     CSVTestLoader,
     CSVDataLoader,
@@ -80,7 +79,10 @@ class DataLoaderTests(unittest.TestCase):
             gcp_service_key=None,  # for CircleCI tests, local test needs key.json
         )
 
-        self.assertTrue(test_loader)
+        self.assertEqual(
+            test_loader.local_file_path,
+            "data/flow_datasets/Afghanistan____.csv",
+        )
 
     def test_ae(self):
         x, y = self.ae_loader[0]
@@ -91,7 +93,7 @@ class DataLoaderTests(unittest.TestCase):
         self.assertEqual(x.shape[0], 30)
         self.assertEqual(x.shape[1], 3)
         self.assertEqual(y.shape[0], 20)
-        # Check first and last dim are not overlapping
+        # Check first and last dim are not overlap
         self.assertFalse(torch.eq(x[29, 0], y[0, 0]))
 
     def test_start_end(self):

--- a/tests/data_loader_tests.py
+++ b/tests/data_loader_tests.py
@@ -78,7 +78,7 @@ class DataLoaderTests(unittest.TestCase):
             interpolate_param=False,
             gcp_service_key=None,  # for CircleCI tests, local test needs key.json
         )
-        self.assertIsInstance(test_loader, CSVDataLoader)
+        self.assertIsInstance(test_loader, CSVTestLoader)
 
     def test_ae(self):
         x, y = self.ae_loader[0]

--- a/tests/data_loader_tests.py
+++ b/tests/data_loader_tests.py
@@ -78,11 +78,7 @@ class DataLoaderTests(unittest.TestCase):
             interpolate_param=False,
             gcp_service_key=None,  # for CircleCI tests, local test needs key.json
         )
-
-        self.assertEqual(
-            test_loader.local_file_path,
-            "data/flow_datasets/Afghanistan____.csv",
-        )
+        self.assertIsInstance(test_loader, CSVDataLoader)
 
     def test_ae(self):
         x, y = self.ae_loader[0]

--- a/tests/data_loader_tests.py
+++ b/tests/data_loader_tests.py
@@ -78,7 +78,7 @@ class DataLoaderTests(unittest.TestCase):
             interpolate_param=False,
             gcp_service_key=None,  # for CircleCI tests, local test needs key.json
         )
-        self.assertIsInstance(test_loader, CSVTestLoader)
+        self.assertIsInstance(test_loader, CSVDataLoader)
 
     def test_ae(self):
         x, y = self.ae_loader[0]

--- a/tests/dsanet.json
+++ b/tests/dsanet.json
@@ -44,7 +44,7 @@
       },
       "lr": 0.03,
       "epochs": 1,
-      "batch_size":4
+      "batch_size":9
    
    },
    "GCS": false,
@@ -59,7 +59,7 @@
   "inference_params":
   {     
         "datetime_start":"2016-05-31",
-         "hours_to_forecast":334, 
+         "hours_to_forecast":100, 
          "test_csv_path":"tests/test_data/keag_small.csv",
          "decoder_params":{
            "decoder_function": "simple_decode", 

--- a/tests/dsanet.json
+++ b/tests/dsanet.json
@@ -12,7 +12,7 @@
       "dsanet_d_inner": 2048,
       "dsanet_n_layers": 2,
       "dsanet_n_head": 8,
-      "dropout": 0.1
+      "dropout": 0.11
    },
    "n_targets":4,
    "dataset_params":

--- a/tests/dsanet.json
+++ b/tests/dsanet.json
@@ -44,7 +44,7 @@
       },
       "lr": 0.03,
       "epochs": 1,
-      "batch_size":9
+      "batch_size":4
    
    },
    "GCS": false,
@@ -59,7 +59,7 @@
   "inference_params":
   {     
         "datetime_start":"2016-05-31",
-         "hours_to_forecast":100, 
+         "hours_to_forecast":334, 
          "test_csv_path":"tests/test_data/keag_small.csv",
          "decoder_params":{
            "decoder_function": "simple_decode", 

--- a/tests/test_informer.json
+++ b/tests/test_informer.json
@@ -73,7 +73,7 @@
    "inference_params":
    {     
          "datetime_start":"2016-05-30",
-          "hours_to_forecast":336, 
+          "hours_to_forecast":100, 
           "test_csv_path":"tests/test_data/keag_small.csv",
           "decoder_params":{
             "decoder_function": "greedy_decode", 

--- a/tests/test_informer.json
+++ b/tests/test_informer.json
@@ -73,7 +73,7 @@
    "inference_params":
    {     
          "datetime_start":"2016-05-30",
-          "hours_to_forecast":100, 
+          "hours_to_forecast":300, 
           "test_csv_path":"tests/test_data/keag_small.csv",
           "decoder_params":{
             "decoder_function": "greedy_decode", 


### PR DESCRIPTION
This PR adds support for data-loaders (CSVTestLoader and CSVDataLoader) to ingest a data-frame directly rather than load a CSV file. This is useful in particular for inference mode where end users often have a dataframe already in code and wouldn't want to ingest a csv.