### PR TITLE
save_path has type `str` but used as type `None`

### DIFF
--- a/flood_forecast/da_rnn/train_da.py
+++ b/flood_forecast/da_rnn/train_da.py
@@ -29,7 +29,7 @@ def da_rnn(train_data: TrainData,
            learning_rate=0.01,
            batch_size=128,
            param_output_path="",
-           save_path: str = None) -> Tuple[dict, DaRnnNet]:
+           save_path: str = "") -> Tuple[dict, DaRnnNet]:
     """
     n_targs: The number of target columns (not steps)
     T: The number timesteps in the window


### PR DESCRIPTION
"filename": "flood_forecast/da_rnn/train_da.py"
"warning_type": "Incompatible variable type [9]"
"warning_message": " save_path is declared to have type `str` but is used as type `None`."
"warning_line": 32
"fix": None to ""